### PR TITLE
feat: upgrades for verifier crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,12 @@ byteorder = { version = "1.0", features = ["i128"], default-features = false }
 crunchy = "0.2.1"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 rustc-hex = { version = "2", default-features = false }
-sp1-lib = "1.2.0-rc1"
 cfg-if = "1.0.0"
 bytemuck = { version = "1.16.1", features = ["derive"] }
-num-bigint = "0.4.6"
+num-bigint = { version = "0.4.6", default-features = false}
+
+[target.'cfg(target_os = "zkvm")'.dependencies]
+sp1-lib = "1.2.0-rc1"
 
 [dev-dependencies]
 rand = { version = "0.8.3", features = ["std_rng"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,10 @@ lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 rustc-hex = { version = "2", default-features = false }
 cfg-if = "1.0.0"
 bytemuck = { version = "1.16.1", features = ["derive"] }
-num-bigint = { version = "0.4.6", default-features = false}
+num-bigint = { version = "0.4.6", default-features = false }
 
 [target.'cfg(target_os = "zkvm")'.dependencies]
-sp1-lib = "1.2.0-rc1"
+sp1-lib = "3.0.0"
 
 [dev-dependencies]
 rand = { version = "0.8.3", features = ["std_rng"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-bn"
-version = "0.7.1"
+version = "0.6.0"
 authors = [
     "Sean Bowe <ewillbefull@gmail.com>",
     "Parity Technologies <admin@parity.io>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-bn"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
     "Sean Bowe <ewillbefull@gmail.com>",
     "Parity Technologies <admin@parity.io>",

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -132,12 +132,6 @@ impl Fr {
 
     #[inline]
     #[allow(dead_code)]
-    pub fn inv(&self) -> u128 {
-        unimplemented!("n' inverse is not used")
-    }
-
-    #[inline]
-    #[allow(dead_code)]
     pub fn raw(&self) -> &U256 {
         unimplemented!("raw representation is not in Montgomery form")
     }
@@ -152,6 +146,16 @@ impl Fr {
         self.0.mul(&other.0, &Self::modulus());
 
         self
+    }
+
+    // This is used for arithmetic in unconstrained mode
+    fn cpu_inverse(mut self) -> Option<Self> {
+        if self.is_zero() {
+            None
+        } else {
+            self.0.invert(&Self::modulus());
+            Some(self)
+        }
     }
 }
 
@@ -175,22 +179,13 @@ impl FieldElement for Fr {
         self.0.is_zero()
     }
 
-    fn inverse(mut self) -> Option<Self> {
-        if self.is_zero() {
-            None
-        } else {
-            self.0.invert(&Self::modulus());
-            Some(self)
-        }
-    }
-
-    fn inverse_unconstrained(self) -> Option<Self> {
+    fn inverse(self) -> Option<Self> {
         #[cfg(target_os = "zkvm")]
         {
             // Compute the inverse using the zkvm syscall
             sp1_lib::unconstrained! {
                 let mut buf = [0u8; 33];
-                self.inverse().map(|inv| {
+                self.cpu_inverse().map(|inv| {
                     let bytes = cast::<[u128; 2], [u8; 32]>(inv.0.0);
                     buf[0..32].copy_from_slice(&bytes);
                     buf[32] = 1;
@@ -211,7 +206,7 @@ impl FieldElement for Fr {
         }
         #[cfg(not(target_os = "zkvm"))]
         {
-            self.inverse()
+            self.cpu_inverse()
         }
     }
 }
@@ -459,12 +454,6 @@ impl Fq {
 
     #[inline]
     #[allow(dead_code)]
-    pub fn inv(&self) -> u128 {
-        unimplemented!("n' inverse is not used")
-    }
-
-    #[inline]
-    #[allow(dead_code)]
     pub fn raw(&self) -> &U256 {
         unimplemented!("raw representation is not in Montgomery form")
     }
@@ -499,6 +488,17 @@ impl Fq {
     pub(crate) fn cpu_neg(mut self) -> Fq {
         self.0.neg(&Self::modulus());
         self
+    }
+
+    // This is used for arithmetic in unconstrained mode
+    pub(crate) fn cpu_inverse(self) -> Option<Fq> {
+        if self.is_zero() {
+            None
+        } else {
+            let mut inv = self;
+            inv.0.invert(&Fq::modulus());
+            Some(inv)
+        }
     }
 
     #[inline]
@@ -573,23 +573,13 @@ impl FieldElement for Fq {
         self.0.is_zero()
     }
 
-    fn inverse(self) -> Option<Fq> {
-        if self.is_zero() {
-            None
-        } else {
-            let mut inv = self;
-            inv.0.invert(&Fq::modulus());
-            Some(inv)
-        }
-    }
-
-    fn inverse_unconstrained(self) -> Option<Self> {
+    fn inverse(self) -> Option<Self> {
         #[cfg(target_os = "zkvm")]
         {
             // Compute the inverse using the zkvm syscall
             sp1_lib::unconstrained! {
                 let mut buf = [0u8; 33];
-                self.inverse().map(|inv| {
+                self.cpu_inverse().map(|inv| {
                     let bytes = cast::<[u128; 2], [u8; 32]>(inv.0.0);
                     buf[0..32].copy_from_slice(&bytes);
                     buf[32] = 1;
@@ -610,7 +600,7 @@ impl FieldElement for Fq {
         }
         #[cfg(not(target_os = "zkvm"))]
         {
-            self.inverse()
+            self.cpu_inverse()
         }
     }
 }

--- a/src/fields/fq12.rs
+++ b/src/fields/fq12.rs
@@ -60,7 +60,7 @@ impl Fq12 {
     }
 
     fn final_exponentiation_first_chunk(&self) -> Option<Fq12> {
-        match self.inverse_unconstrained() {
+        match self.inverse() {
             Some(b) => {
                 let a = self.unitary_inverse();
                 let c = a * b;
@@ -378,10 +378,6 @@ impl FieldElement for Fq12 {
                 c0: self.c0 * t,
                 c1: -(self.c1 * t),
             })
-    }
-
-    fn inverse_unconstrained(self) -> Option<Self> {
-        self.inverse() // same as constrained
     }
 }
 

--- a/src/fields/fq2.rs
+++ b/src/fields/fq2.rs
@@ -1,6 +1,7 @@
 use crate::arith::{U256, U512};
 use crate::fields::{const_fq, FieldElement, Fq};
 use bytemuck::{AnyBitPattern, NoUninit};
+use core::cmp::Ordering;
 use core::ops::{Add, Div, Mul, Neg, Sub};
 use rand::Rng;
 
@@ -34,7 +35,7 @@ pub const fn fq2_nonresidue() -> Fq2 {
     )
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, NoUninit, AnyBitPattern, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, NoUninit, AnyBitPattern)]
 #[repr(C)]
 pub struct Fq2 {
     c0: Fq,
@@ -363,6 +364,23 @@ impl Neg for Fq2 {
             c0: -self.c0,
             c1: -self.c1,
         }
+    }
+}
+
+/// `Fq2` elements are ordered lexicographically.
+impl Ord for Fq2 {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.c1.cmp(&other.c1) {
+            Ordering::Greater => Ordering::Greater,
+            Ordering::Less => Ordering::Less,
+            Ordering::Equal => self.c0.cmp(&other.c0),
+        }
+    }
+}
+
+impl PartialOrd for Fq2 {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/src/fields/fq2.rs
+++ b/src/fields/fq2.rs
@@ -256,15 +256,18 @@ impl FieldElement for Fq2 {
         // "High-Speed Software Implementation of the Optimal Ate Pairing
         // over Barreto–Naehrig Curves"; Algorithm 8
 
-        (self
+        match (self
             .c0
-            .cpu_mul(self.c0)
-            .cpu_sub((self.c1.cpu_mul(self.c1)).cpu_mul(fq_non_residue())))
-        .inverse()
-        .map(|t| Fq2 {
-            c0: self.c0.cpu_mul(t),
-            c1: (self.c1.cpu_mul(t)).cpu_neg(),
-        })
+            .mul(self.c0)
+            .sub((self.c1.mul(self.c1)).mul(fq_non_residue())))
+        .inverse_unconstrained()
+        {
+            Some(t) => Some(Fq2 {
+                c0: self.c0.mul(t),
+                c1: (self.c1.mul(t)).cpu_neg(),
+            }),
+            None => None,
+        }
     }
 
     fn inverse_unconstrained(self) -> Option<Self> {

--- a/src/fields/fq2.rs
+++ b/src/fields/fq2.rs
@@ -7,13 +7,12 @@ use rand::Rng;
 
 use super::Sqrt;
 
-cfg_if::cfg_if! {
-    if #[cfg(target_os = "zkvm")] {
-        use sp1_lib::io::{hint_slice, read_vec};
-        use core::convert::TryInto;
-        use bytemuck::{cast, cast_ref, cast_mut};
-    }
-}
+#[cfg(target_os = "zkvm")]
+use {
+    bytemuck::{cast, cast_mut, cast_ref},
+    core::convert::TryInto,
+    sp1_lib::io::{hint_slice, read_vec},
+};
 
 #[inline]
 fn fq_non_residue() -> Fq {
@@ -256,24 +255,13 @@ impl FieldElement for Fq2 {
         // "High-Speed Software Implementation of the Optimal Ate Pairing
         // over Barreto–Naehrig Curves"; Algorithm 8
 
-        self.c0
-            .mul(self.c0)
-            .sub((self.c1.mul(self.c1)).mul(fq_non_residue()))
-            .inverse_unconstrained()
-            .map(|t| Fq2 {
-                c0: self.c0.mul(t),
-                c1: (self.c1.mul(t)).neg(),
-            })
-    }
-
-    fn inverse_unconstrained(self) -> Option<Self> {
         #[cfg(target_os = "zkvm")]
         {
             // Compute the inverse using the zkvm syscall
             sp1_lib::unconstrained! {
                 let mut buf = [0u8; 65];
-                self.inverse().map(|inv| {
-                    let bytes = cast::<[u128; 4], [u8; 64]>(inv.to_u512().0);
+                self.cpu_inverse().map(|inv| {
+                    let bytes = cast::<Fq2, [u8; 64]>(inv);
                     buf[0..64].copy_from_slice(&bytes);
                     buf[64] = 1;
                 });
@@ -291,7 +279,7 @@ impl FieldElement for Fq2 {
         }
         #[cfg(not(target_os = "zkvm"))]
         {
-            self.inverse()
+            self.cpu_inverse()
         }
     }
 }
@@ -417,6 +405,22 @@ impl Fq2 {
             }
         }
         res
+    }
+
+    fn cpu_inverse(self) -> Option<Self> {
+        // "High-Speed Software Implementation of the Optimal Ate Pairing
+        // over Barreto–Naehrig Curves"; Algorithm 8
+
+        let x = self
+            .c0
+            .cpu_mul(self.c0)
+            .cpu_sub((self.c1.cpu_mul(self.c1)).cpu_mul(fq_non_residue()))
+            .cpu_inverse()
+            .map(|t| Fq2 {
+                c0: self.c0.cpu_mul(t),
+                c1: (self.c1.cpu_mul(t)).cpu_neg(),
+            });
+        x
     }
 
     fn cpu_sqrt(&self) -> Option<Self> {

--- a/src/fields/fq2.rs
+++ b/src/fields/fq2.rs
@@ -261,8 +261,8 @@ impl FieldElement for Fq2 {
             .sub((self.c1.mul(self.c1)).mul(fq_non_residue()))
             .inverse_unconstrained()
             .map(|t| Fq2 {
-                c0: self.c0.cpu_mul(t),
-                c1: (self.c1.cpu_mul(t)).cpu_neg(),
+                c0: self.c0.mul(t),
+                c1: (self.c1.mul(t)).neg(),
             })
     }
 

--- a/src/fields/fq2.rs
+++ b/src/fields/fq2.rs
@@ -256,18 +256,14 @@ impl FieldElement for Fq2 {
         // "High-Speed Software Implementation of the Optimal Ate Pairing
         // over Barreto–Naehrig Curves"; Algorithm 8
 
-        match (self
-            .c0
+        self.c0
             .mul(self.c0)
-            .sub((self.c1.mul(self.c1)).mul(fq_non_residue())))
-        .inverse_unconstrained()
-        {
-            Some(t) => Some(Fq2 {
-                c0: self.c0.mul(t),
-                c1: (self.c1.mul(t)).cpu_neg(),
-            }),
-            None => None,
-        }
+            .sub((self.c1.mul(self.c1)).mul(fq_non_residue()))
+            .inverse_unconstrained()
+            .map(|t| Fq2 {
+                c0: self.c0.cpu_mul(t),
+                c1: (self.c1.cpu_mul(t)).cpu_neg(),
+            })
     }
 
     fn inverse_unconstrained(self) -> Option<Self> {

--- a/src/fields/fq6.rs
+++ b/src/fields/fq6.rs
@@ -239,10 +239,6 @@ impl FieldElement for Fq6 {
             None => None,
         }
     }
-
-    fn inverse_unconstrained(self) -> Option<Self> {
-        self.inverse() // same as constrained
-    }
 }
 
 impl Mul for Fq6 {

--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -34,7 +34,6 @@ pub trait FieldElement:
         (*self) * (*self)
     }
     fn inverse(self) -> Option<Self>;
-    fn inverse_unconstrained(self) -> Option<Self>;
     fn pow<I: Into<U256>>(&self, by: I) -> Self {
         let mut res = Self::one();
 

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -122,7 +122,6 @@ impl Display for Error {
         }
     }
 }
-extern crate std;
 impl<P: GroupParams> AffineG<P> {
     pub fn new(x: P::Base, y: P::Base) -> Result<Self, Error> {
         let lhs = y.squared();
@@ -256,6 +255,8 @@ impl AffineG1 {
 impl Add<AffineG1> for AffineG1 {
     type Output = AffineG1;
 
+    // We only need the mutability for the zkvm case.
+    #[allow(unused_mut)]
     fn add(mut self, other: AffineG1) -> AffineG1 {
         #[cfg(target_os = "zkvm")]
         {

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -122,7 +122,7 @@ impl Display for Error {
         }
     }
 }
-
+extern crate std;
 impl<P: GroupParams> AffineG<P> {
     pub fn new(x: P::Base, y: P::Base) -> Result<Self, Error> {
         let lhs = y.squared();
@@ -187,8 +187,8 @@ impl<P: GroupParams> AffineG<P> {
     /// This means that, if `P::BaseField: PrimeField`, the results are sorted as integers.
     pub fn get_ys_from_x_unchecked(x: P::Base) -> Option<(P::Base, P::Base)> {
         // Compute the curve equation x^3 + Ax + B.
-        let x3_plus_ax_plus_b = P::add_b(x.squared() * x);
-        let y = x3_plus_ax_plus_b.sqrt()?;
+        let x3_plus_b = P::add_b(x.squared() * x);
+        let y = x3_plus_b.sqrt()?;
         let neg_y = -y;
         match y < neg_y {
             true => Some((y, neg_y)),
@@ -256,7 +256,7 @@ impl AffineG1 {
 impl Add<AffineG1> for AffineG1 {
     type Output = AffineG1;
 
-    fn add(self, other: AffineG1) -> AffineG1 {
+    fn add(mut self, other: AffineG1) -> AffineG1 {
         #[cfg(target_os = "zkvm")]
         {
             let mut out = self;

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -348,7 +348,7 @@ impl<P: GroupParams> G<P> {
                 y: self.y,
             })
         } else {
-            let zinv = self.z.inverse_unconstrained().unwrap();
+            let zinv = self.z.inverse().unwrap();
             let zinv_squared = zinv.squared();
 
             Some(AffineG {

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -256,7 +256,7 @@ impl AffineG1 {
 impl Add<AffineG1> for AffineG1 {
     type Output = AffineG1;
 
-    fn add(mut self, other: AffineG1) -> AffineG1 {
+    fn add(self, other: AffineG1) -> AffineG1 {
         #[cfg(target_os = "zkvm")]
         {
             let mut out = self;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -779,7 +779,6 @@ impl Mul<Fr> for G2 {
         G2(self.0 * other.0)
     }
 }
-extern crate std;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct Gt(fields::Fq12);
@@ -886,7 +885,6 @@ impl AffineG2 {
     }
 
     pub fn get_ys_from_x_unchecked(x: Fq2) -> Option<(Fq2, Fq2)> {
-        std::println!("IN FQ2");
         groups::AffineG2::get_ys_from_x_unchecked(x.0).map(|(neq_y, y)| (Fq2(neq_y), Fq2(y)))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -779,6 +779,7 @@ impl Mul<Fr> for G2 {
         G2(self.0 * other.0)
     }
 }
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct Gt(fields::Fq12);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -779,7 +779,7 @@ impl Mul<Fr> for G2 {
         G2(self.0 * other.0)
     }
 }
-
+extern crate std;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct Gt(fields::Fq12);
@@ -886,6 +886,7 @@ impl AffineG2 {
     }
 
     pub fn get_ys_from_x_unchecked(x: Fq2) -> Option<(Fq2, Fq2)> {
+        std::println!("IN FQ2");
         groups::AffineG2::get_ys_from_x_unchecked(x.0).map(|(neq_y, y)| (Fq2(neq_y), Fq2(y)))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ impl Fr {
         fields::Fr::from_str(s).map(Fr)
     }
     pub fn inverse(&self) -> Option<Self> {
-        self.0.inverse_unconstrained().map(Fr)
+        self.0.inverse().map(Fr)
     }
     pub fn is_zero(&self) -> bool {
         self.0.is_zero()
@@ -213,7 +213,7 @@ impl Fq {
         fields::Fq::from_str(s).map(Fq)
     }
     pub fn inverse(&self) -> Option<Self> {
-        self.0.inverse_unconstrained().map(Fq)
+        self.0.inverse().map(Fq)
     }
     pub fn is_zero(&self) -> bool {
         self.0.is_zero()
@@ -795,7 +795,7 @@ impl Gt {
         Gt(self.0.pow(exp.0))
     }
     pub fn inverse(&self) -> Option<Self> {
-        self.0.inverse_unconstrained().map(Gt)
+        self.0.inverse().map(Gt)
     }
     pub fn final_exponentiation(&self) -> Option<Self> {
         self.0.final_exponentiation().map(Gt)


### PR DESCRIPTION
1. Serialize and deserialize Fq2 in the same format as gnark and arkworks.
2. Flag SP1 inclusion under cfg flag.
3. Refactor inverse_unconstrained and inverse to inverse and cpu_inverse. This makes it easier to choose the correct implementation depending on architecture.
4. Corrected version from 0.7.0 to 0.6.0.

I want to use this branch as the v2 feature branch for now, then merge it into patch-v0.6.0, which I imagine to be our main branch. 

| Operation | V1 Cycle count (mil) | V2 Cycle Count (mil) |
|--------|--------|--------|
| 2x Batch Pairing | 6.09  | 5.176 |
| Groth16 Verification | unimplemented | 6.77 | 