### PR TITLE
feat: fixes for verifier crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
 
 script:
+  - cargo clippy -- -D warnings
   - cargo test --release
   - cargo test --release --no-default-features
   - cargo check --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,12 @@ byteorder = { version = "1.0", features = ["i128"], default-features = false }
 crunchy = "0.2.1"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 rustc-hex = { version = "2", default-features = false }
-sp1-lib = "1.2.0-rc1"
 cfg-if = "1.0.0"
 bytemuck = { version = "1.16.1", features = ["derive"] }
-num-bigint = "0.4.6"
+num-bigint = { version = "0.4.6", default-features = false}
+
+[target.'cfg(target_os = "zkvm")'.dependencies]
+sp1-lib = "1.2.0-rc1"
 
 [dev-dependencies]
 rand = { version = "0.8.3", features = ["std_rng"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,10 @@ lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 rustc-hex = { version = "2", default-features = false }
 cfg-if = "1.0.0"
 bytemuck = { version = "1.16.1", features = ["derive"] }
-num-bigint = { version = "0.4.6", default-features = false}
+num-bigint = { version = "0.4.6", default-features = false }
 
 [target.'cfg(target_os = "zkvm")'.dependencies]
-sp1-lib = "1.2.0-rc1"
+sp1-lib = "3.0.0"
 
 [dev-dependencies]
 rand = { version = "0.8.3", features = ["std_rng"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-bn"
-version = "0.7.1"
+version = "0.6.0"
 authors = [
     "Sean Bowe <ewillbefull@gmail.com>",
     "Parity Technologies <admin@parity.io>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-bn"
-version = "0.6.0"
+version = "0.7.0"
 authors = [
     "Sean Bowe <ewillbefull@gmail.com>",
     "Parity Technologies <admin@parity.io>",
@@ -20,14 +20,15 @@ default = []
 name = "api"
 
 [dependencies]
-rand = { version = "0.8.3", default-features = false }
+rand = { version = "0.8.5", default-features = false }
 byteorder = { version = "1.0", features = ["i128"], default-features = false }
 crunchy = "0.2.1"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 rustc-hex = { version = "2", default-features = false }
-sp1-lib = { git = "https://github.com/succinctlabs/sp1.git", branch = "dev" }
+sp1-lib = "1.2.0-rc1"
 cfg-if = "1.0.0"
 bytemuck = { version = "1.16.1", features = ["derive"] }
+num-bigint = "0.4.6"
 
 [dev-dependencies]
 rand = { version = "0.8.3", features = ["std_rng"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-bn"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
     "Sean Bowe <ewillbefull@gmail.com>",
     "Parity Technologies <admin@parity.io>",

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -286,7 +286,7 @@ impl MulAssign for Fr {
         }
         #[cfg(not(target_os = "zkvm"))]
         {
-            self.cpu_mul(other);
+            *self = self.cpu_mul(other);
         }
     }
 }

--- a/src/fields/fq12.rs
+++ b/src/fields/fq12.rs
@@ -1,6 +1,6 @@
 use crate::arith::U256;
 use crate::fields::{const_fq, FieldElement, Fq, Fq2, Fq6};
-use core::ops::{Add, Mul, Neg, Sub};
+use core::ops::{Add, Div, Mul, Neg, Sub};
 use rand::Rng;
 
 fn frobenius_coeffs_c1(power: usize) -> Fq2 {
@@ -56,7 +56,7 @@ pub struct Fq12 {
 
 impl Fq12 {
     pub fn new(c0: Fq6, c1: Fq6) -> Self {
-        Fq12 { c0: c0, c1: c1 }
+        Fq12 { c0, c1 }
     }
 
     fn final_exponentiation_first_chunk(&self) -> Option<Fq12> {
@@ -99,9 +99,8 @@ impl Fq12 {
         let s = self.unitary_inverse();
         let t = s * l;
         let u = t.frobenius_map(3);
-        let v = u * r;
 
-        v
+        u * r
     }
 
     pub fn final_exponentiation(&self) -> Option<Fq12> {
@@ -373,13 +372,12 @@ impl FieldElement for Fq12 {
     }
 
     fn inverse(self) -> Option<Self> {
-        match (self.c0.squared() - (self.c1.squared().mul_by_nonresidue())).inverse() {
-            Some(t) => Some(Fq12 {
+        (self.c0.squared() - (self.c1.squared().mul_by_nonresidue()))
+            .inverse()
+            .map(|t| Fq12 {
                 c0: self.c0 * t,
                 c1: -(self.c1 * t),
-            }),
-            None => None,
-        }
+            })
     }
 
     fn inverse_unconstrained(self) -> Option<Self> {
@@ -398,6 +396,14 @@ impl Mul for Fq12 {
             c0: bb.mul_by_nonresidue() + aa,
             c1: (self.c0 + self.c1) * (other.c0 + other.c1) - aa - bb,
         }
+    }
+}
+
+impl Div for Fq12 {
+    type Output = Fq12;
+
+    fn div(self, other: Fq12) -> Fq12 {
+        self * other.inverse().expect("division by zero")
     }
 }
 

--- a/src/fields/fq2.rs
+++ b/src/fields/fq2.rs
@@ -1,6 +1,7 @@
 use crate::arith::{U256, U512};
 use crate::fields::{const_fq, FieldElement, Fq};
 use bytemuck::{AnyBitPattern, NoUninit};
+use core::cmp::Ordering;
 use core::ops::{Add, Div, Mul, Neg, Sub};
 use rand::Rng;
 
@@ -34,7 +35,7 @@ pub const fn fq2_nonresidue() -> Fq2 {
     )
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, NoUninit, AnyBitPattern, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, NoUninit, AnyBitPattern)]
 #[repr(C)]
 pub struct Fq2 {
     c0: Fq,
@@ -363,6 +364,23 @@ impl Neg for Fq2 {
             c0: -self.c0,
             c1: -self.c1,
         }
+    }
+}
+
+/// `Fq2` elements are ordered lexicographically.
+impl Ord for Fq2 {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.c1.cmp(&other.c1) {
+            Ordering::Greater => Ordering::Greater,
+            Ordering::Less => Ordering::Less,
+            Ordering::Equal => self.c0.cmp(&other.c0),
+        }
+    }
+}
+
+impl PartialOrd for Fq2 {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/src/fields/fq2.rs
+++ b/src/fields/fq2.rs
@@ -256,15 +256,18 @@ impl FieldElement for Fq2 {
         // "High-Speed Software Implementation of the Optimal Ate Pairing
         // over Barreto–Naehrig Curves"; Algorithm 8
 
-        (self
+        match (self
             .c0
-            .cpu_mul(self.c0)
-            .cpu_sub((self.c1.cpu_mul(self.c1)).cpu_mul(fq_non_residue())))
-        .inverse()
-        .map(|t| Fq2 {
-            c0: self.c0.cpu_mul(t),
-            c1: (self.c1.cpu_mul(t)).cpu_neg(),
-        })
+            .mul(self.c0)
+            .sub((self.c1.mul(self.c1)).mul(fq_non_residue())))
+        .inverse_unconstrained()
+        {
+            Some(t) => Some(Fq2 {
+                c0: self.c0.mul(t),
+                c1: (self.c1.mul(t)).cpu_neg(),
+            }),
+            None => None,
+        }
     }
 
     fn inverse_unconstrained(self) -> Option<Self> {

--- a/src/fields/fq6.rs
+++ b/src/fields/fq6.rs
@@ -1,5 +1,5 @@
 use crate::fields::{const_fq, FieldElement, Fq, Fq2};
-use core::ops::{Add, Mul, Neg, Sub};
+use core::ops::{Add, Div, Mul, Neg, Sub};
 use rand::Rng;
 
 fn frobenius_coeffs_c1(n: usize) -> Fq2 {
@@ -99,11 +99,7 @@ pub struct Fq6 {
 
 impl Fq6 {
     pub fn new(c0: Fq2, c1: Fq2, c2: Fq2) -> Self {
-        Fq6 {
-            c0: c0,
-            c1: c1,
-            c2: c2,
-        }
+        Fq6 { c0, c1, c2 }
     }
 
     pub fn mul_by_nonresidue(&self) -> Self {
@@ -320,6 +316,14 @@ impl Add for Fq6 {
             c1: self.c1 + other.c1,
             c2: self.c2 + other.c2,
         }
+    }
+}
+
+impl Div for Fq6 {
+    type Output = Fq6;
+
+    fn div(self, other: Fq6) -> Fq6 {
+        self * other.inverse().expect("division by zero")
     }
 }
 

--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -5,7 +5,7 @@ mod fq6;
 
 use crate::arith::U256;
 use alloc::fmt::Debug;
-use core::ops::{Add, Mul, Neg, Sub};
+use core::ops::{Add, Div, Mul, Neg, Sub};
 use rand::Rng;
 
 pub use self::fp::{const_fq, Fq, Fr};
@@ -21,6 +21,7 @@ pub trait FieldElement:
     + Sub<Output = Self>
     + Mul<Output = Self>
     + Neg<Output = Self>
+    + Div<Output = Self>
     + PartialEq
     + Eq
     + Debug
@@ -46,6 +47,10 @@ pub trait FieldElement:
 
         res
     }
+}
+
+pub trait Sqrt: Sized {
+    fn sqrt(&self) -> Option<Self>;
 }
 
 #[cfg(test)]

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -122,7 +122,6 @@ impl Display for Error {
         }
     }
 }
-extern crate std;
 impl<P: GroupParams> AffineG<P> {
     pub fn new(x: P::Base, y: P::Base) -> Result<Self, Error> {
         let lhs = y.squared();
@@ -256,6 +255,8 @@ impl AffineG1 {
 impl Add<AffineG1> for AffineG1 {
     type Output = AffineG1;
 
+    // We only need the mutability for the zkvm case.
+    #[allow(unused_mut)]
     fn add(mut self, other: AffineG1) -> AffineG1 {
         #[cfg(target_os = "zkvm")]
         {

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -122,7 +122,7 @@ impl Display for Error {
         }
     }
 }
-
+extern crate std;
 impl<P: GroupParams> AffineG<P> {
     pub fn new(x: P::Base, y: P::Base) -> Result<Self, Error> {
         let lhs = y.squared();
@@ -187,8 +187,8 @@ impl<P: GroupParams> AffineG<P> {
     /// This means that, if `P::BaseField: PrimeField`, the results are sorted as integers.
     pub fn get_ys_from_x_unchecked(x: P::Base) -> Option<(P::Base, P::Base)> {
         // Compute the curve equation x^3 + Ax + B.
-        let x3_plus_ax_plus_b = P::add_b(x.squared() * x);
-        let y = x3_plus_ax_plus_b.sqrt()?;
+        let x3_plus_b = P::add_b(x.squared() * x);
+        let y = x3_plus_b.sqrt()?;
         let neg_y = -y;
         match y < neg_y {
             true => Some((y, neg_y)),
@@ -256,7 +256,7 @@ impl AffineG1 {
 impl Add<AffineG1> for AffineG1 {
     type Output = AffineG1;
 
-    fn add(self, other: AffineG1) -> AffineG1 {
+    fn add(mut self, other: AffineG1) -> AffineG1 {
         #[cfg(target_os = "zkvm")]
         {
             let mut out = self;

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -146,6 +146,10 @@ impl<P: GroupParams> AffineG<P> {
         }
     }
 
+    pub fn new_unchecked(x: P::Base, y: P::Base) -> Self {
+        AffineG { x, y }
+    }
+
     pub fn zero() -> Self {
         AffineG {
             x: P::Base::zero(),
@@ -693,14 +697,14 @@ fn twist_mul_by_q_y() -> Fq2 {
     )
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct EllCoeffs {
     pub ell_0: Fq2,
     pub ell_vw: Fq2,
     pub ell_vv: Fq2,
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct G2Precomp {
     pub q: AffineG<G2Params>,
     pub coeffs: Vec<EllCoeffs>,

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -348,7 +348,7 @@ impl<P: GroupParams> G<P> {
                 y: self.y,
             })
         } else {
-            let zinv = self.z.inverse_unconstrained().unwrap();
+            let zinv = self.z.inverse().unwrap();
             let zinv_squared = zinv.squared();
 
             Some(AffineG {

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -256,7 +256,7 @@ impl AffineG1 {
 impl Add<AffineG1> for AffineG1 {
     type Output = AffineG1;
 
-    fn add(mut self, other: AffineG1) -> AffineG1 {
+    fn add(self, other: AffineG1) -> AffineG1 {
         #[cfg(target_os = "zkvm")]
         {
             let mut out = self;

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -12,7 +12,7 @@ use core::{
     ops::{Add, Mul, Neg, Sub},
 };
 
-use rand::{thread_rng, Rng};
+use rand::Rng;
 #[cfg(target_os = "zkvm")]
 use sp1_lib::{syscall_bn254_add, syscall_bn254_double};
 // This is the NAF version of ate_loop_count. Entries are all mod 4, so 3 = -1
@@ -4622,6 +4622,7 @@ fn test_y_at_point_at_infinity() {
 
 #[test]
 fn test_to_from_affine() {
+    use rand::thread_rng;
     let mut rng = thread_rng();
     for _ in 0..10 {
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -776,7 +776,7 @@ impl Mul<Fr> for G2 {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct Gt(fields::Fq12);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -779,7 +779,6 @@ impl Mul<Fr> for G2 {
         G2(self.0 * other.0)
     }
 }
-extern crate std;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct Gt(fields::Fq12);
@@ -886,7 +885,6 @@ impl AffineG2 {
     }
 
     pub fn get_ys_from_x_unchecked(x: Fq2) -> Option<(Fq2, Fq2)> {
-        std::println!("IN FQ2");
         groups::AffineG2::get_ys_from_x_unchecked(x.0).map(|(neq_y, y)| (Fq2(neq_y), Fq2(y)))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -561,6 +561,10 @@ impl AffineG1 {
         Ok(AffineG1(groups::AffineG1::new(x.0, y.0)?))
     }
 
+    pub fn new_unchecked(x: Fq, y: Fq) -> Self {
+        AffineG1(groups::AffineG1::new_unchecked(x.0, y.0))
+    }
+
     pub fn zero() -> Self {
         AffineG1(groups::AffineG1::zero())
     }
@@ -855,6 +859,10 @@ impl AffineG2 {
 
     pub fn new(x: Fq2, y: Fq2) -> Result<Self, GroupError> {
         Ok(AffineG2(groups::AffineG2::new(x.0, y.0)?))
+    }
+
+    pub fn new_unchecked(x: Fq2, y: Fq2) -> Self {
+        AffineG2(groups::AffineG2::new_unchecked(x.0, y.0))
     }
 
     pub fn x(&self) -> Fq2 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -779,6 +779,7 @@ impl Mul<Fr> for G2 {
         G2(self.0 * other.0)
     }
 }
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct Gt(fields::Fq12);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -779,7 +779,7 @@ impl Mul<Fr> for G2 {
         G2(self.0 * other.0)
     }
 }
-
+extern crate std;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct Gt(fields::Fq12);
@@ -886,6 +886,7 @@ impl AffineG2 {
     }
 
     pub fn get_ys_from_x_unchecked(x: Fq2) -> Option<(Fq2, Fq2)> {
+        std::println!("IN FQ2");
         groups::AffineG2::get_ys_from_x_unchecked(x.0).map(|(neq_y, y)| (Fq2(neq_y), Fq2(y)))
     }
 }


### PR DESCRIPTION
1. Serialize and deserialize Fq2 in the same format as gnark and arkworks.
2. Flag SP1 inclusion under cfg flag. 
3. Small optimizations to use syscalls while computing fq2 inverse. 
4. Merge the rest of bhargav's changes into 0.6.0

Ideally, I'd make this PR into a different branch, but I don't have access to sp1-patches.